### PR TITLE
fix: blockscout verifier updated and improved

### DIFF
--- a/boa/explorer.py
+++ b/boa/explorer.py
@@ -6,27 +6,8 @@ from typing import Optional
 
 from boa.rpc import json
 from boa.util.abi import Address
+from boa.util.cached_session import get_session
 from boa.verifiers import ContractVerifier, VerificationResult
-
-try:
-    from requests_cache import CachedSession
-
-    def filter_fn(response):
-        return response.ok and _is_success_response(response.json())
-
-    SESSION = CachedSession(
-        "~/.cache/titanoboa/explorer_cache",
-        filter_fn=filter_fn,
-        allowable_codes=[200],
-        cache_control=True,
-        expire_after=3600 * 6,
-        stale_if_error=True,
-        stale_while_revalidate=True,
-    )
-except ImportError:
-    from requests import Session
-
-    SESSION = Session()
 
 DEFAULT_ETHERSCAN_URI = "https://api.etherscan.io/v2/api"
 VERSION_RE = re.compile(r"v(\d+\.\d+\.\d+)(\+commit.*)?")
@@ -242,3 +223,7 @@ def _is_rate_limited(data: dict) -> bool:
     :return: True if rate limited, False otherwise
     """
     return "rate limit" in data.get("result", "") and data.get("status") == "0"
+
+
+# @dev put the session here so it can be used by the explorer
+SESSION = get_session(_is_success_response)

--- a/boa/util/cached_session.py
+++ b/boa/util/cached_session.py
@@ -1,0 +1,32 @@
+from typing import Optional
+from requests import Response, Session
+
+
+def get_session(callback: Optional[callable] = lambda _: True) -> Optional[Session]:
+    """Returns a session for making HTTP requests.
+    If the `requests_cache` library is available, it will return a `CachedSession`.
+    Else it will return a regular `Session`.
+    """
+    SESSION = None
+
+    try:
+        from requests_cache import CachedSession
+
+        def filter_fn(response: Response) -> bool:
+            return response.ok and callback(response.json())
+
+        SESSION = CachedSession(
+            "~/.cache/titanoboa/explorer_cache",
+            filter_fn=filter_fn,
+            allowable_codes=[200],
+            cache_control=True,
+            expire_after=3600 * 6,
+            stale_if_error=True,
+            stale_while_revalidate=True,
+        )
+    except ImportError:
+        from requests import Session
+
+        SESSION = Session()
+
+    return SESSION

--- a/tests/integration/network/sepolia/test_sepolia_env.py
+++ b/tests/integration/network/sepolia/test_sepolia_env.py
@@ -44,8 +44,7 @@ def simple_contract():
 @pytest.fixture(scope="module", params=[Etherscan, Blockscout])
 def verifier(request):
     if request.param == Blockscout:
-        api_key = os.getenv("BLOCKSCOUT_API_KEY")
-        return Blockscout("https://eth-sepolia.blockscout.com", api_key)
+        return Blockscout("https://eth-sepolia.blockscout.com")
     elif request.param == Etherscan:
         api_key = os.environ["ETHERSCAN_API_KEY"]
         return Etherscan("https://api.etherscan.io/v2/api", api_key)


### PR DESCRIPTION
## Related issues:
- #403 

---

### What I did

Fix  compatibility Blockscout APIs by  introducing a unified session management utility, and updating the Blockscout verification logic to remove reliance on API keys.

### How I did it

#### Updates to API Compatibility:

* **Blockscout Enhancements**: Removed the `api_key` attribute from the `Blockscout` class and updated verification logic to check contract existence and verification status before proceeding. Introduced retries for contract creation using the session utility. 

#### Session Management Improvements:

* **Unified Session Utility**: Added `get_session` in `boa/util/cached_session.py` to abstract session creation. This utility supports both `requests_cache` and fallback to regular `requests.Session`, enabling consistent session handling across the codebase.
* **Session Integration**: Replaced direct session instantiation with the new `get_session` utility in `boa/explorer.py` and `boa/verifiers.py`. 

#### Test Case Updates:

* **Blockscout Tests**: Updated integration tests to reflect the removal of API keys for Blockscout.

### How to verify it

Run the following test:
```
pytest tests/integration/network/sepolia/test_sepolia_env.py -vvv -k test_verify
```

### Description for the changelog

- Removed API key dependency
- Streamlined verification logic
- Improved contract existence/status checks.
- Unified session utility to standardize and simplify HTTP session management across the codebase.

### Cute Animal Picture

![Owls](https://images.pexels.com/photos/105804/pexels-photo-105804.jpeg)
